### PR TITLE
initial argocd managed by argocd

### DIFF
--- a/argocd/kustomization.yaml
+++ b/argocd/kustomization.yaml
@@ -5,9 +5,9 @@ namespace: argocd
 
 resources:
 - base/namespace.yaml
-- base/argocd-server-http-ingress.yaml
+# - base/argocd-server-http-ingress.yaml
 - https://raw.githubusercontent.com/argoproj/argo-cd/v2.7.2/manifests/install.yaml
 
 patches:
-- path: overlays/production/argocd-server-service.yaml
+- path: overlays/production/argocd-server-service-nodeport.yaml
 - path: overlays/production/argocd-cmd-params-cm.yaml

--- a/argocd/overlays/production/argocd-server-service-nodeport.yaml
+++ b/argocd/overlays/production/argocd-server-service-nodeport.yaml
@@ -3,4 +3,4 @@ kind: Service
 metadata:
   name: argocd-server
 spec:
-  type: LoadBalancer
+  type: NodePort

--- a/argoproj/base/argo-cd.yaml
+++ b/argoproj/base/argo-cd.yaml
@@ -1,0 +1,14 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argo-cd
+  namespace: argocd
+spec:
+  destination:
+    namespace: argocd
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: argocd
+    repoURL: https://github.com/ecarlste/argoproj-deployments
+    targetRevision: HEAD

--- a/argoproj/kustomization.yaml
+++ b/argoproj/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - base/argo-cd.yaml


### PR DESCRIPTION
this pr does the following:
- sets up argocd to manage argocd
- temporarily changes the argocd-server service to NodePort rather than LoadBalancer